### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : "~7.0",
-        "illuminate/support": "~5.1",
+        "illuminate/support": "5.1||5.2||5.3||5.4||5.5",
         "themsaid/laravel-langman": "^1.3",
         "ctf0/package-changelog": "^1.0"
     },


### PR DESCRIPTION
Since Laravel does not follow semver. `^5.1` or `~5.1`  would mean that the library supports 5.1 to 5.99.. even though any of these versions could break your app. 